### PR TITLE
feat: docker support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@
 .vs/
 [Bb]in/
 [Oo]bj/
+[Oo]ut/
 _UpgradeReport_Files/
 [Pp]ackages/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM mcr.microsoft.com/dotnet/sdk:7.0-jammy AS build-env
+
+WORKDIR /App
+COPY . ./
+RUN dotnet restore
+RUN dotnet publish -c Release -o Out
+
+FROM mcr.microsoft.com/dotnet/aspnet:7.0-jammy
+
+RUN apt-get update && apt-get install -y wget
+RUN wget -q https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+RUN apt-get install -y ./google-chrome-stable_current_amd64.deb
+
+WORKDIR /App
+COPY --from=build-env /App/Out .
+ENTRYPOINT ["dotnet", "KeyDropGiveawayBot.dll"]

--- a/README.md
+++ b/README.md
@@ -41,6 +41,27 @@ To run this project, you will need to add the following environment variables to
 
 `userAgent`: Get your user-agent information from https://www.whatsmyua.info/
 
+## Docker
+
+You can containerize this project with Docker. It allows you to run it somewhere on your server without the need have it running on your personal machine.
+
+### Configuration
+
+The container runs under Linux operating system, thus, to be able to bypass CloudFlare protection you also need a Linux browser `User Agent`.
+
+To get this, grab the value of `Latest Chrome on Linux User Agents` from [this website](https://www.whatismybrowser.com/guides/the-latest-user-agent/chrome), e.g.
+
+```
+Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/113.0.0.0 Safari/537.36
+```
+
+### Usage
+
+```
+docker build -t keydrop-giveaway-bot:latest .
+docker run -it keydrop-giveaway-bot -e sessionId="your_session_id" -e userAgent="user_agent_from_previous_section"
+```
+
 
 ## Screenshots
 

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -46,7 +46,7 @@ using var host = Host.CreateDefaultBuilder()
             return provider.Create(new StringBuilderPooledObjectPolicy());
         });
     })
-    .ConfigureAppConfiguration((context, config) => { config.AddJsonFile("appsettings.json", false, true); })
+    .ConfigureAppConfiguration((context, config) => { config.AddJsonFile("appsettings.json", false, true).AddEnvironmentVariables(); })
     .Build();
 
 #endregion


### PR DESCRIPTION
Resolves #5

### Notes
- I had to resign from the (smaller) `alpine` docker image, because there were some issues with the Chrome driver working with the bot. I switched to the `jammy` image, which is the latest Ubuntu.
- There's a caveat that you need to enter a Linux browser user agent to make it work. Otherwise, CloudFlare rejects the browser and the bot does not work. I described it in the readme - hope that's enough.